### PR TITLE
12 model fails to parse the json response due to unexpected attributes

### DIFF
--- a/exchange_rate_client/commons.py
+++ b/exchange_rate_client/commons.py
@@ -1,4 +1,4 @@
-from typing import Optional, Mapping, Any, Dict
+from typing import Optional, Dict
 
 from pydantic import BaseModel, ConfigDict
 

--- a/exchange_rate_client/commons.py
+++ b/exchange_rate_client/commons.py
@@ -1,14 +1,18 @@
 from typing import Optional, Mapping, Any, Dict
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
-class ExchangeRates(BaseModel):
+class BaseResponseModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+
+class ExchangeRates(BaseResponseModel):
     base_code: str
     conversion_rates: Dict[str, float]
 
 
-class PairConversion(BaseModel):
+class PairConversion(BaseResponseModel):
     time_last_update_unix: Optional[int] = None
     time_last_update_utc: Optional[str] = None
     time_next_update_unix: Optional[int] = None
@@ -19,7 +23,7 @@ class PairConversion(BaseModel):
     conversion_result: Optional[float] = None
 
 
-class APIQuotaStatus(BaseModel):
+class APIQuotaStatus(BaseResponseModel):
     plan_quota: int
     requests_remaining: int
     refresh_day_of_month: int

--- a/tests/test_client_v6_exchange_rates.py
+++ b/tests/test_client_v6_exchange_rates.py
@@ -40,6 +40,7 @@ class TestExchangeRateV6Client(unittest.TestCase):
                 "EGP": 15.7361,
                 "EUR": 0.9013,
             },
+            "extra_attribute": "extra",  # Extra attribute that will be ignored
         }
 
         mock_get.side_effect = [mock_supported_codes_response, mock_response]

--- a/tests/test_client_v6_fetch_quota_info.py
+++ b/tests/test_client_v6_fetch_quota_info.py
@@ -24,6 +24,7 @@ class TestExchangeRateV6Client(unittest.TestCase):
             "plan_quota": 30000,
             "requests_remaining": 25623,
             "refresh_day_of_month": 17,
+            "extra_attribute": "extra",  # Extra attribute that will be ignored
         }
 
         expected = APIQuotaStatus(

--- a/tests/test_client_v6_pair_conversion.py
+++ b/tests/test_client_v6_pair_conversion.py
@@ -38,6 +38,7 @@ class TestExchangeRateV6Client(unittest.TestCase):
             "base_code": "EUR",
             "target_code": "USD",
             "conversion_rate": 1.0278,
+            "extra_attribute": "extra",  # Extra attribute that will be ignored
         }
 
         mock_get.side_effect = [mock_supported_codes_response, mock_response]

--- a/tests/test_client_v6_pair_conversion.py
+++ b/tests/test_client_v6_pair_conversion.py
@@ -79,6 +79,7 @@ class TestExchangeRateV6Client(unittest.TestCase):
             "target_code": "USD",
             "conversion_rate": 1.0278,
             "conversion_result": 4.1112,
+            "extra_attribute": "extra",  # Extra attribute that will be ignored
         }
 
         mock_get.side_effect = [mock_supported_codes_response, mock_response]


### PR DESCRIPTION
- [x] Fix model parsing
- [x] Improve tests to use extra attributes in answers
- [x] Remove unused imports in commons.py 